### PR TITLE
Resolve Comparison Bug and Variable Shadowing Bug

### DIFF
--- a/app/src/main/jni/Main.cpp
+++ b/app/src/main/jni/Main.cpp
@@ -38,9 +38,9 @@ void checkHardware() {
     string device = ::getSystemProperty("ro.product.device");
     string hardware = ::getSystemProperty("ro.hardware");
 
-    for (const string& product : products) {
-        if (strcmp(product.c_str(), product.c_str()) != 0) {
-            detections.append(string("- Detected Product: ") + product + "\n");
+    for (const string& _product : products) {
+        if (strcmp(_product.c_str(), product.c_str()) == 0) {
+            detections.append(string("- Detected Product: ") + _product + "\n");
         }
     }
 


### PR DESCRIPTION
- Fix the Comparison Bug by correctly comparing innerProduct with the outer scope product.
- Eliminate Variable Shadowing Bug by renaming inner loop variable for clarity.